### PR TITLE
Feature/flip characters placed on stage + Hiding UI

### DIFF
--- a/Assets/Data/Instruments/Keyboard.asset
+++ b/Assets/Data/Instruments/Keyboard.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d749a04237734f408779eb0ca40782fa, type: 3}
   m_Name: Keyboard
   m_EditorClassIdentifier: 
+  isBehindMusician: 0
   instrumentType: 4
   inGameSprite: {fileID: 21300000, guid: 92d76d5570bb20941a1bb9681e7e77f2, type: 3}
   uiSprite: {fileID: 21300000, guid: 92d76d5570bb20941a1bb9681e7e77f2, type: 3}

--- a/Assets/Data/Instruments/Synth.asset
+++ b/Assets/Data/Instruments/Synth.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d749a04237734f408779eb0ca40782fa, type: 3}
   m_Name: Synth
   m_EditorClassIdentifier: 
+  isBehindMusician: 1
   instrumentType: 12
   inGameSprite: {fileID: 21300000, guid: 1ae767afd153e3e41bbd9ab7f53b78b1, type: 3}
   uiSprite: {fileID: 21300000, guid: 1ae767afd153e3e41bbd9ab7f53b78b1, type: 3}

--- a/Assets/Data/Instruments/Xylophone.asset
+++ b/Assets/Data/Instruments/Xylophone.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d749a04237734f408779eb0ca40782fa, type: 3}
   m_Name: Xylophone
   m_EditorClassIdentifier: 
+  isBehindMusician: 1
   instrumentType: 5
   inGameSprite: {fileID: 21300000, guid: 79c25f4c0497e5f429d319f182b57c66, type: 3}
   uiSprite: {fileID: 21300000, guid: 79c25f4c0497e5f429d319f182b57c66, type: 3}

--- a/Assets/Prefabs/InstrumentUI.prefab
+++ b/Assets/Prefabs/InstrumentUI.prefab
@@ -207,7 +207,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1843115109
   m_SortingLayer: 2
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 9b2a092324524d74ebb151dc867fed59, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -557,24 +557,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3259586509700368134, guid: cc69cc2118bdf034aa21ddb2e2350b09, type: 3}
       propertyPath: performances.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3259586509700368134, guid: cc69cc2118bdf034aa21ddb2e2350b09, type: 3}
       propertyPath: performances.Array.data[0]
       value: 
-      objectReference: {fileID: 11400000, guid: 6828129f825298346beed61c8dd58004, type: 2}
+      objectReference: {fileID: 11400000, guid: 8b8358785fe59a0488277589b1c20887, type: 2}
     - target: {fileID: 3259586509700368134, guid: cc69cc2118bdf034aa21ddb2e2350b09, type: 3}
       propertyPath: performances.Array.data[1]
       value: 
-      objectReference: {fileID: 11400000, guid: df9e029da18b4634799f429091298cf3, type: 2}
+      objectReference: {fileID: 11400000, guid: 6828129f825298346beed61c8dd58004, type: 2}
     - target: {fileID: 3259586509700368134, guid: cc69cc2118bdf034aa21ddb2e2350b09, type: 3}
       propertyPath: performances.Array.data[2]
       value: 
-      objectReference: {fileID: 11400000, guid: 8b8358785fe59a0488277589b1c20887, type: 2}
+      objectReference: {fileID: 11400000, guid: dff2b02f7043b90488d63c2dedc777a7, type: 2}
     - target: {fileID: 3259586509700368134, guid: cc69cc2118bdf034aa21ddb2e2350b09, type: 3}
       propertyPath: performances.Array.data[3]
       value: 
-      objectReference: {fileID: 11400000, guid: 7e06cc2efbc9e9345829889bf316dd07, type: 2}
+      objectReference: {fileID: 11400000, guid: df9e029da18b4634799f429091298cf3, type: 2}
     - target: {fileID: 3259586509700368134, guid: cc69cc2118bdf034aa21ddb2e2350b09, type: 3}
       propertyPath: performances.Array.data[4]
       value: 
@@ -2315,6 +2315,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 13364969784502363, guid: ad71de9892fe2a144bc088080451df92, type: 3}
+      propertyPath: MusicianSelectionPhaseObjects.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 13364969784502363, guid: ad71de9892fe2a144bc088080451df92, type: 3}
+      propertyPath: MusicianSelectionPhaseObjects.Array.data[0]
+      value: 
+      objectReference: {fileID: 801986402}
     - target: {fileID: 438201028041345224, guid: ad71de9892fe2a144bc088080451df92, type: 3}
       propertyPath: m_Name
       value: GamePhaseManagers

--- a/Assets/_Scripts/Gameplay/InstrumentDataSO.cs
+++ b/Assets/_Scripts/Gameplay/InstrumentDataSO.cs
@@ -6,6 +6,7 @@ namespace _Scripts.Gameplay
     [Serializable] [CreateAssetMenu]
     public class InstrumentDataSO : ScriptableObject
     {
+        public bool isBehindMusician;
         public InstrumentType instrumentType;
         public Sprite inGameSprite;
         public Sprite uiSprite;

--- a/Assets/_Scripts/Gameplay/PerformanceLibrary.cs
+++ b/Assets/_Scripts/Gameplay/PerformanceLibrary.cs
@@ -3,10 +3,12 @@ using UnityEngine;
 
 public class PerformanceLibrary : MonoBehaviour
 {
+    [Header("A Library Class for ALL performances.")]
+    [Header("Used to search for performanceKeys in saving/loading")]
     public PerformanceDataSO[] performances;
     public static PerformanceDataSO[] performancesStatic;
 
-    private void Start()
+    private void Awake()
     {
         performancesStatic = performances;
     }

--- a/Assets/_Scripts/Gameplay/StagePlacement.cs
+++ b/Assets/_Scripts/Gameplay/StagePlacement.cs
@@ -5,17 +5,18 @@ public class StagePlacement : MonoBehaviour
 {
     [SerializeField] private Musician occupyingMusician;
     [SerializeField] private Instrument occupyingInstrument;
+    [SerializeField] private FacingDirection stageSide;
+
     public static event Action<StagePlacement> OnMusicianPlaced; 
     public static event Action<StagePlacement> OnInstrumentPlaced;
 
-    [SerializeField] private FacingDirection stageSide;
-
-    void Start()
+    public void Start()
     {
         if (transform.position.x < -1) stageSide = FacingDirection.Left;
         else if (transform.position.x > 1) stageSide = FacingDirection.Right;
         else stageSide = FacingDirection.Forward;
     }
+
     public bool SetMusician(Musician musician, Transform worldMusician)
     {
         if (occupyingMusician) return false;

--- a/Assets/_Scripts/Gameplay/StagePlacement.cs
+++ b/Assets/_Scripts/Gameplay/StagePlacement.cs
@@ -8,11 +8,23 @@ public class StagePlacement : MonoBehaviour
     public static event Action<StagePlacement> OnMusicianPlaced; 
     public static event Action<StagePlacement> OnInstrumentPlaced;
 
+    [SerializeField] private FacingDirection stageSide;
+
+    void Start()
+    {
+        if (transform.position.x < -1) stageSide = FacingDirection.Left;
+        else if (transform.position.x > 1) stageSide = FacingDirection.Right;
+        else stageSide = FacingDirection.Forward;
+    }
     public bool SetMusician(Musician musician, Transform worldMusician)
     {
         if (occupyingMusician) return false;
 
         occupyingMusician = musician;
+        if (stageSide != occupyingMusician.GetAllMusicianData().worldFacingDirection && stageSide != FacingDirection.Forward)
+        {
+            worldMusician.GetComponent<SpriteRenderer>().flipX = true;
+        }
         worldMusician.SetPositionAndRotation(transform.position, transform.rotation);
         worldMusician.parent = transform;
         OnMusicianPlaced?.Invoke(this);
@@ -24,6 +36,16 @@ public class StagePlacement : MonoBehaviour
         if (occupyingInstrument) return false;
 
         occupyingInstrument = instrument;
+        SpriteRenderer worldSprite = worldInstrument.GetComponent<SpriteRenderer>();
+        if (stageSide != occupyingInstrument.data.facingDirection && stageSide != FacingDirection.Forward)
+        {
+            worldSprite.flipX = true;
+        }
+
+        if (occupyingInstrument.data.isBehindMusician)
+        {
+            worldSprite.sortingOrder = -1;
+        }
         worldInstrument.SetPositionAndRotation(transform.position, transform.rotation);
         worldInstrument.parent = transform;
         OnInstrumentPlaced?.Invoke(this);
@@ -47,7 +69,7 @@ public class StagePlacement : MonoBehaviour
             Destroy(occupyingInstrument.worldObject.gameObject);
         if (occupyingMusician)
             Destroy(occupyingMusician.worldObject.gameObject);
-
+        
         occupyingInstrument = null;
         occupyingMusician = null;
 

--- a/Assets/_Scripts/Managers/NightManager.cs
+++ b/Assets/_Scripts/Managers/NightManager.cs
@@ -163,8 +163,7 @@ public class NightManager : MonoBehaviour
         if (currentNight > nights.Count) currentNight = nights.Count;
         OnPerformanceSelected?.Invoke(performanceDataSo);
         
-        // What game phase should we be transitioning to?
-        //phaseManager.SetCurrentPhase(PhaseManager.GamePhase.???);
+        phaseManager.SetCurrentPhase(PhaseManager.GamePhase.MusicianSelection);
     }
 
     public void EndNight()


### PR DESCRIPTION
- Musician Select UI now hides on a performance starting.
- All instruments are infront by default, but can be set behind by Data>IsBehindMusician boolean.
- Placements now have a FacingDirection.
- Flips musicians/Instruments appropriately based on FacingDirection.